### PR TITLE
moved splittedFileName generation under file presence check

### DIFF
--- a/gist-embed.js
+++ b/gist-embed.js
@@ -12,13 +12,20 @@ $(function(){
       line,
       data = {};
 
+<<<<<<< Updated upstream
     id = $elem.attr('id') || '';
     file = $elem.attr('data-file');
     line = $elem.attr('data-line');
     splittedFileName = file.split('.').join('-');
+=======
+    id              = $elem.attr('id') || '';
+    file            = $elem.attr('data-file');
+    line            = $elem.attr('data-line');
+>>>>>>> Stashed changes
     
     if(file){
       data.file = file;
+      splittedFileName = file.split('.').join('-');
     }
 
     //if the id doesn't begin with 'gist-', then ignore the code block


### PR DESCRIPTION
Fixed a bug when data-file was not provided.
