### PR TITLE
Feature/show multiple lines

### DIFF
--- a/gist-embed.js
+++ b/gist-embed.js
@@ -12,9 +12,9 @@ $(function(){
       line,
       data = {};
 
-    id = $elem.attr('id') || '';
-    file = $elem.attr('data-file');
-    line = $elem.attr('data-line');
+    id              = $elem.attr('id') || '';
+    file            = $elem.attr('data-file');
+    line            = $elem.attr('data-line');
     splittedFileName = file.split('.').join('-');
     
     if(file){
@@ -54,20 +54,35 @@ $(function(){
               l.href = response.stylesheet;
               head.insertBefore(l, head.firstChild);
             }
+
+            var random = Math.floor(Math.random() * 100000);
+            $elem.html("<div id='" + random + "'>" + response.div + "</div>");
+
             if(line){
               var lineNumbers = getLineNumbers(line);
-              var lineCodes = new Array(lineNumbers.length);
 
-              for(var i = 0; i < lineNumbers.length; i++){
-                if($(response.div).find('#file-' + splittedFileName + '-LC' + lineNumbers[i])[0]){
-                  lineCodes[i] = $(response.div).find('#file-' + splittedFileName + '-LC' + lineNumbers[i])[0].innerHTML;
+              $('#' + random).find('.line').each(function(index){
+                if(($.inArray(index + 1, lineNumbers)) == -1){
+                  $(this).remove();
                 }
-              }
-              html = basicStructureForMultipleLines(id, lineCodes, splittedFileName);
-              $elem.html(html);
+              });
+
+              lineNumber = 1;
+              $('#' + random).find('.line-number').each(function(index){
+                if(($.inArray(index + 1, lineNumbers)) == -1){
+                  $(this).remove();
+                }
+                else{
+                  $(this).html(lineNumber++);
+                }
+              });
             }
-            else{
-              $elem.html(response.div);
+            if($elem.attr('data-showFooter') && $elem.attr('data-showFooter') == "false"){
+              $('#' + random).find('.gist-meta').remove();
+            }
+
+            if($elem.attr('data-showLineNumbers') && $elem.attr('data-showLineNumbers') == "false"){
+              $('#' + random).find('.line-numbers').remove();
             }
           }else{
             $elem.html('Failed loading gist ' + url);
@@ -89,26 +104,13 @@ function getLineNumbers(lineRangeString){
   for(var k = 0; k < lineNumberSections.length; k++){
     var range = lineNumberSections[k].split('-');
     if(range.length == 2){
-      for(var i = range[0]; i <= range[1]; i++){
+      for(var i = parseInt(range[0]); i <= range[1]; i++){
         lineNumbers.push(i);
       }
     }
     else if(range.length == 1){
-      lineNumbers.push(range[0]);
+      lineNumbers.push(parseInt(range[0]));
     }
   }
   return lineNumbers;
-}
-
-function basicStructureForMultipleLines(gistId, lineCodes, splittedFileName){
-  html = '<div id="gist' + gistId + '" class="gist"><div class="gist-file">' +
-         '<div class="gist-data gist-syntax"><div class="file-data">' +
-         '<table cellpadding="0" cellspacing="0" class="lines highlight">' +
-         '<tbody><tr><td class="line-data"><pre class="line-pre">';
-  for(var i = 0; i < lineCodes.length; i++){
-    html += '<div class="line" id="file-' + splittedFileName + '-LC' + (i + 1) + '">' +
-    lineCodes[i] + '</div>';
-  }
-  html += '</pre></td></tr></tbody></table></div></div></div></div>';
-  return html;
 }


### PR DESCRIPTION
Multiple lines feature added. User can add `data-line` attribute to `code` tag with value something like `1-5,89,45`. To embed multiple lines, user has to include `data-file` attribute with the desired file name.
