### PR TITLE
Use full jQuery instead of $ alias for noConflict support.

### DIFF
--- a/gist-embed.js
+++ b/gist-embed.js
@@ -1,6 +1,6 @@
 //author: Blair Vanderhoof
 //https://github.com/blairvanderhoof/gist-embed
-$(function(){
+jQuery(function($){
   var gistMarkerId = 'gist-';
 
   //find all code elements containing "gist-" the id attribute.


### PR DESCRIPTION
This will mean the plugin works with jQuery running without the $ alias (ie. WordPress' bundled jQuery)
