### PR TITLE
Fixed gist id must be a number and `data-line` not working

### DIFF
--- a/gist-embed.js
+++ b/gist-embed.js
@@ -35,28 +35,23 @@ $(function(){
     //get the numeric id from the id attribute of the element holder
     id = id.substr(0, gistMarkerId.length) === gistMarkerId ? id.replace(gistMarkerId, '') : null;
 
-    //make sure result is a numeric id
-    if(!isNaN(parseInt(id, 10))){
-      url = baseurl + '/' + id + '.json';
-      //loading
-      $elem.html('Loading gist ' + url + (data.file ? ', file: ' + data.file : '') + '...');
-      //request the json version of this gist
-      $.ajax({
-        type: 'GET',
-        async: true,
-        jsonpCallback: callbackFunction,
-        contentType: "application/json",
-        url: url,
-        data: data,
-        dataType: 'jsonp',
-        timeout: 10000,
-        error: function(){
-          $elem.html('Failed loading gist ' + url + (data.file ? ', file: ' + data.file : '') + '...');
-        }
-      });
-    }else{
-      $elem.html('Failed loading gist with incorrect id format: ' + $elem.attr('id'));
-    }
+    url = baseurl + '/' + id + '.json';
+    //loading
+    $elem.html('Loading gist ' + url + (data.file ? ', file: ' + data.file : '') + '...');
+    //request the json version of this gist
+    $.ajax({
+      type: 'GET',
+      async: true,
+      jsonpCallback: callbackFunction,
+      contentType: "application/json",
+      url: url,
+      data: data,
+      dataType: 'jsonp',
+      timeout: 10000,
+      error: function(){
+        $elem.html('Failed loading gist ' + url + (data.file ? ', file: ' + data.file : '') + '...');
+      }
+    });
   });
 });
 
@@ -98,24 +93,15 @@ function myCallback(response, timestamp){
 
     if(line){
       var lineNumbers = getLineNumbers(line);
-      $('#' + timestamp).find('.line').each(function(index){
-        if(($.inArray(index + 1, lineNumbers)) == -1){
+      $('#' + timestamp + ' .js-file-line-container').find('tr').each(function(index){
+        if(($.inArray(index + 1, lineNumbers)) === -1){
           $(this).remove();
-        }
-      });
-
-      var lineNumber = 1;
-      $('#' + timestamp).find('.line-number').each(function(index){
-        if(($.inArray(index + 1, lineNumbers)) == -1){
-          $(this).remove();
-        }
-        else{
-          $(this).html(lineNumber++);
         }
       });
     }
     if($elem.attr('data-showFooter') && $elem.attr('data-showFooter') == "false"){
       $('#' + timestamp).find('.gist-meta').remove();
+      $('#' + timestamp).find('.gist-data').css("border-bottom", "none");
     }
 
     if($elem.attr('data-showLineNumbers') && $elem.attr('data-showLineNumbers') == "false"){


### PR DESCRIPTION
The following bugs where fixed:
- `data-line` attribute not working anymore, probably due to layout change on GitHub's part
- the id of a Gist is not an number only (anymore?). For example, this is a valid Gist id: `aa01a6093a52b3fc7f6e91852beb9b69`

The following improvements where added:
- when removing the footer, also remove the double bottom border of the code snippet